### PR TITLE
Namespaced symbols and tagged values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,5 +19,6 @@ pub enum Value {
     List(Vec<Value>),
     Vector(Vec<Value>),
     Map(BTreeMap<Value, Value>),
-    Set(BTreeSet<Value>)
+    Set(BTreeSet<Value>),
+    TaggedValue(String, Box<Value>),
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -232,7 +232,11 @@ impl<'a> Parser<'a> {
                     "nil"     => Value::Nil,
                     otherwise => Value::Symbol(otherwise.into())
                 })
-            }
+            },
+            (_, '/') => {
+                self.chars.next();
+                Ok(Value::Symbol("/".into()))
+            },
             _ => unimplemented!(),
         })
     }
@@ -268,7 +272,7 @@ fn is_symbol_head(ch: char) -> bool {
 
 fn is_symbol_tail(ch: char) -> bool {
     is_symbol_head(ch) || match ch {
-        '0' ... '9' | ':' | '#' => true,
+        '0' ... '9' | ':' | '#' | '/' => true,
         _ => false
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -220,6 +220,24 @@ impl<'a> Parser<'a> {
                             }
                         }
                     },
+                    Some((start,  ch)) if is_symbol_head(ch) => {
+                        self.chars.next();
+                        let end = self.advance_while(is_symbol_tail);
+
+                        let tag = &self.str[start..end];
+                        let value = self.read();
+
+                        match value {
+                            Some(Ok(v)) => return Ok(Value::TaggedValue(tag.into(),
+                                                                        Box::new(v))),
+                            Some(e) => return e,
+                            None => return Err(Error {
+                                lo: start,
+                                hi: self.str.len(),
+                                message: "malformed tagged value".into()
+                            })
+                        }
+                    },
                     _ => unimplemented!()
                 }
             }

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -97,6 +97,8 @@ foo
 .*+!-_?$%&=<>:#123
 +
 -
+namespaced/symbol
+/
 "#);
     assert_eq!(parser.read(), Some(Ok(Value::Symbol("foo".into()))));
     assert_eq!(parser.read(), Some(Ok(Value::Symbol("+foo".into()))));
@@ -106,6 +108,9 @@ foo
                Some(Ok(Value::Symbol(".*+!-_?$%&=<>:#123".into()))));
     assert_eq!(parser.read(), Some(Ok(Value::Symbol("+".into()))));
     assert_eq!(parser.read(), Some(Ok(Value::Symbol("-".into()))));
+    assert_eq!(parser.read(),
+               Some(Ok(Value::Symbol("namespaced/symbol".into()))));
+    assert_eq!(parser.read(), Some(Ok(Value::Symbol("/".into()))));
     assert_eq!(parser.read(), None);
 }
 


### PR DESCRIPTION
Namespaced symbols and tagged values are common in the edn that I interact with. This PR adds support for both.